### PR TITLE
Add __gt__ and __lt__ overrides for TagBase.

### DIFF
--- a/taggit/models.py
+++ b/taggit/models.py
@@ -28,10 +28,10 @@ class TagBase(models.Model):
         return self.name
 
     def __gt__(self, other):
-        return self.name > other.name
+        return self.name.lower() > other.name.lower()
 
     def __lt__(self, other):
-        return self.name < other.name
+        return self.name.lower() < other.name.lower()
 
     class Meta:
         abstract = True

--- a/taggit/models.py
+++ b/taggit/models.py
@@ -27,6 +27,12 @@ class TagBase(models.Model):
     def __str__(self):
         return self.name
 
+    def __gt__(self, other):
+        return self.name > other.name
+
+    def __lt__(self, other):
+        return self.name < other.name
+
     class Meta:
         abstract = True
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -112,13 +112,13 @@ class TagModelTestCase(BaseTaggingTransactionTestCase):
 
     def test_gt(self):
         high = self.tag_model.objects.create(name='high')
-        low = self.tag_model.objects.create(name='low')
+        low = self.tag_model.objects.create(name='Low')
         self.assertTrue(low > high)
         self.assertFalse(high > low)
 
     def test_lt(self):
         high = self.tag_model.objects.create(name='high')
-        low = self.tag_model.objects.create(name='low')
+        low = self.tag_model.objects.create(name='Low')
         self.assertTrue(high < low)
         self.assertFalse(low < high)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -110,6 +110,18 @@ class TagModelTestCase(BaseTaggingTransactionTestCase):
                 r"Expected <class 'django.db.models.base.ModelBase'> or str.")):
             apple.tags.add(1)
 
+    def test_gt(self):
+        high = self.tag_model.objects.create(name='high')
+        low = self.tag_model.objects.create(name='low')
+        self.assertTrue(low > high)
+        self.assertFalse(high > low)
+
+    def test_lt(self):
+        high = self.tag_model.objects.create(name='high')
+        low = self.tag_model.objects.create(name='low')
+        self.assertTrue(high < low)
+        self.assertFalse(low < high)
+
 
 class TagModelDirectTestCase(TagModelTestCase):
     food_model = DirectFood


### PR DESCRIPTION
Fixes an incompatibility with django-modelcluster and, by extension, Wagtail.

@incuna/backend review please? :)